### PR TITLE
Fix issue with arrow functions in node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var annotate = require('fn-annotate');
 var P = typeof Promise === 'undefined' ? require('es6-promise').Promise : Promise;
 
 function applyNew(ctor, args) {
-  var instance = Object.create(ctor.prototype);
+  var instance = Object.create(ctor.prototype || {});
   return ctor.apply(instance, args) || instance;
 }
 


### PR DESCRIPTION
Arrow functions don't have a `.prototype` property.

This could also be changed to

    Object.create(ctor.prototype || null)

However using an object maintains the same behaviour as using arrow functions with babel.